### PR TITLE
[NOCARD] Add outface for iptables masquerade

### DIFF
--- a/config/crd/bases/cloud.spaceship.com_networkattachments.yaml
+++ b/config/crd/bases/cloud.spaceship.com_networkattachments.yaml
@@ -71,6 +71,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  outface:
+                    type: string
                   source:
                     type: string
                 required:
@@ -131,7 +133,8 @@ spec:
                 type: array
               routes:
                 items:
-                  description: Static routes
+                  description: Static routes The Via parameter could be ip address
+                    or device name.
                   properties:
                     destination:
                       type: string

--- a/config/crd/bases/cloud.spaceship.com_networks.yaml
+++ b/config/crd/bases/cloud.spaceship.com_networks.yaml
@@ -71,6 +71,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  outface:
+                    type: string
                   source:
                     type: string
                 required:
@@ -129,7 +131,8 @@ spec:
                 type: array
               routes:
                 items:
-                  description: Static routes
+                  description: Static routes The Via parameter could be ip address
+                    or device name.
                   properties:
                     destination:
                       type: string

--- a/controllers/firewall.go
+++ b/controllers/firewall.go
@@ -28,14 +28,13 @@ func EnableMasquerade(ipmasq *networkv1alpha1.Masquerade) error {
 
 	// Make sure arp request won't go outside of compute node
 	// ebtables-nft -I FORWARD -p ARP -o br2710 --arp-ip-dst 169.254.1.1 -j DROP
-
 	rule := []string{"-p", "ARP", "-o", ipmasq.Bridge, "--arp-ip-dst", virtualIpaddress, "-j", "DROP"}
 
 	if err := ebtables.AddRule(rule...); err != nil {
 		return err
 	}
 
-	if err := iptables.AddRule(ipmasq.Bridge, ipmasq.Source, ipmasq.Ignore); err != nil {
+	if err := iptables.AddRule(ipmasq.Bridge, ipmasq.Source, ipmasq.Ignore, ipmasq.Outface); err != nil {
 		return err
 	}
 

--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -34,6 +34,10 @@ func renderRule(rule *Rules) []string {
 		prepareRule = append(prepareRule, "-j", rule.action)
 	}
 
+	if rule.outface != "" {
+		prepareRule = append(prepareRule, "-o", rule.outface)
+	}
+
 	if rule.comment != "" {
 		prepareRule = append(prepareRule, "-m comment --comment", rule.comment)
 	}
@@ -41,7 +45,7 @@ func renderRule(rule *Rules) []string {
 	return prepareRule
 }
 
-func AddRule(name string, source string, ignore []string) error {
+func AddRule(name string, source string, ignore []string, outface string) error {
 	// Default iptables rules
 	rules := []Rules{
 		{
@@ -51,9 +55,10 @@ func AddRule(name string, source string, ignore []string) error {
 			action: fmt.Sprintf("%s-POSTROUTING", name),
 		},
 		{
-			table:  "nat",
-			chain:  fmt.Sprintf("%s-POSTROUTING", name),
-			action: "MASQUERADE",
+			table:   "nat",
+			chain:   fmt.Sprintf("%s-POSTROUTING", name),
+			outface: outface,
+			action:  "MASQUERADE",
 		},
 	}
 


### PR DESCRIPTION
## What does this change resolve?
Add outface for iptables masquerade
```
  ipMasq:
    bridge: br2723
    enabled: true
    ignore:
    - 192.168.0.0/23
    - 10.25.37.0/24
    - 10.0.2.0/24
    - 10.142.0.0/15
    - 10.144.0.0/16
    source: 192.168.0.0/23
    outface: bond0.2721
```

#### Open questions or TODOs before merging if any
<!-- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!-- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->
