### PR TITLE
[CU-85zt6z71q] Fix issue with incorrect gateway mac address

### DIFF
--- a/controllers/firewall.go
+++ b/controllers/firewall.go
@@ -2,17 +2,20 @@ package controllers
 
 import (
 	"fmt"
+	"net"
 
 	networkv1alpha1 "github.com/NCCloud/tabby-cni/api/v1alpha1"
 	"github.com/NCCloud/tabby-cni/pkg/ebtables"
 	"github.com/NCCloud/tabby-cni/pkg/iptables"
 	"github.com/containernetworking/plugins/pkg/utils/sysctl"
+	"github.com/j-keck/arping"
 )
 
 const (
-	IPv4InterfaceArpProxySysctlTemplate string = "net.ipv4.conf.%s.proxy_arp"
-	ipv4Forward                         string = "net.ipv4.ip_forward"
-	virtualIpaddress                    string = "169.254.1.1"
+	IPv4InterfaceArpProxySysctlTemplate   string = "net.ipv4.conf.%s.proxy_arp"
+	IPv4InterfaceDelayProxySysctlTemplate string = "net.ipv4.neigh.%s.proxy_delay"
+	ipv4Forward                           string = "net.ipv4.ip_forward"
+	virtualIpaddress                      string = "169.254.1.1"
 )
 
 func EnableMasquerade(ipmasq *networkv1alpha1.Masquerade) error {
@@ -22,19 +25,30 @@ func EnableMasquerade(ipmasq *networkv1alpha1.Masquerade) error {
 		return fmt.Errorf("failed to set proxy_arp on newly added interface %s: %v", ipmasq.Bridge, err)
 	}
 
+	ipv4SysctlValueName = fmt.Sprintf(IPv4InterfaceDelayProxySysctlTemplate, ipmasq.Bridge)
+	if _, err := sysctl.Sysctl(ipv4SysctlValueName, "0"); err != nil {
+		return fmt.Errorf("failed to set proxy_delay on newly added interface %s: %v", ipmasq.Bridge, err)
+	}
+
 	if _, err := sysctl.Sysctl(ipv4Forward, "1"); err != nil {
 		return fmt.Errorf("failed to set ip_forward=1: %v", err)
 	}
 
 	// Make sure arp request won't go outside of compute node
 	// ebtables-nft -I FORWARD -p ARP -o br2710 --arp-ip-dst 169.254.1.1 -j DROP
-	rule := []string{"-p", "ARP", "-o", ipmasq.Bridge, "--arp-ip-dst", virtualIpaddress, "-j", "DROP"}
+	rule := []string{"-p", "ARP", "--logical-out", ipmasq.Bridge, "--arp-ip-dst", virtualIpaddress, "-j", "DROP"}
 
 	if err := ebtables.AddRule(rule...); err != nil {
 		return err
 	}
 
 	if err := iptables.AddRule(ipmasq.Bridge, ipmasq.Source, ipmasq.Ignore, ipmasq.Outface); err != nil {
+		return err
+	}
+
+	// After applying ebtables arp rules, it's better to send arp gratuitous request to make sure all overcloud
+	// nodes use proper mac for default gateway.
+	if err := arping.GratuitousArpOverIfaceByName(net.ParseIP(virtualIpaddress), ipmasq.Bridge); err != nil {
 		return err
 	}
 

--- a/controllers/network_attachment_controller.go
+++ b/controllers/network_attachment_controller.go
@@ -100,8 +100,10 @@ func (r *NetworkAttachmentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 				return ctrl.Result{}, err
 			}
 
-			if err = DeleteMasquerade(&networkAttachment.Spec.IpMasq); err != nil {
-				return ctrl.Result{}, err
+			if networkAttachment.Spec.IpMasq.Enabled {
+				if err = DeleteMasquerade(&networkAttachment.Spec.IpMasq); err != nil {
+					return ctrl.Result{}, err
+				}
 			}
 
 			log.Log.Info("NetworkAttachment: Removing Finalizer for network after successfully perform the operations")
@@ -130,6 +132,7 @@ func (r *NetworkAttachmentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			return ctrl.Result{}, err
 		}
 	}
+
 	if err = r.DiffNetwork(ctx, req); err != nil {
 		return ctrl.Result{}, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,16 @@ require (
 )
 
 require (
+	github.com/j-keck/arping v1.0.3 // indirect
+	github.com/josharian/native v1.0.0 // indirect
+	github.com/mdlayher/arp v0.0.0-20220512170110-6706a2966875 // indirect
+	github.com/mdlayher/ethernet v0.0.0-20220221185849-529eae5b6118 // indirect
+	github.com/mdlayher/packet v1.0.0 // indirect
+	github.com/mdlayher/socket v0.2.1 // indirect
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
+)
+
+require (
 	cloud.google.com/go v0.97.0 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest v0.11.27 // indirect

--- a/go.sum
+++ b/go.sum
@@ -199,6 +199,7 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
@@ -237,9 +238,13 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/j-keck/arping v1.0.3 h1:aeVk5WnsK6xPaRsFt5wV6W2x5l/n5XBNp0MMr/FEv2k=
+github.com/j-keck/arping v1.0.3/go.mod h1:aJbELhR92bSk7tp79AWM/ftfc90EfEi2bQJrbBFOsPw=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/josharian/native v1.0.0 h1:Ts/E8zCSEsG17dUqv7joXJFybuMLjQfWE04tsBODTxk=
+github.com/josharian/native v1.0.0/go.mod h1:7X/raswPFr05uY3HiLlYeyQntB6OO7E/d2Cu7qoaN2w=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -268,6 +273,14 @@ github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJ
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/mdlayher/arp v0.0.0-20220512170110-6706a2966875 h1:ql8x//rJsHMjS+qqEag8n3i4azw1QneKh5PieH9UEbY=
+github.com/mdlayher/arp v0.0.0-20220512170110-6706a2966875/go.mod h1:kfOoFJuHWp76v1RgZCb9/gVUc7XdY877S2uVYbNliGc=
+github.com/mdlayher/ethernet v0.0.0-20220221185849-529eae5b6118 h1:2oDp6OOhLxQ9JBoUuysVz9UZ9uI6oLUbvAZu0x8o+vE=
+github.com/mdlayher/ethernet v0.0.0-20220221185849-529eae5b6118/go.mod h1:ZFUnHIVchZ9lJoWoEGUg8Q3M4U8aNNWA3CVSUTkW4og=
+github.com/mdlayher/packet v1.0.0 h1:InhZJbdShQYt6XV2GPj5XHxChzOfhJJOMbvnGAmOfQ8=
+github.com/mdlayher/packet v1.0.0/go.mod h1:eE7/ctqDhoiRhQ44ko5JZU2zxB88g+JH/6jmnjzPjOU=
+github.com/mdlayher/socket v0.2.1 h1:F2aaOwb53VsBE+ebRS9bLd7yPOfYUMC8lOODdCBDY6w=
+github.com/mdlayher/socket v0.2.1/go.mod h1:QLlNPkFR88mRUNQIzRBMfXxwKal8H7u1h3bL1CV+f0E=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -493,6 +506,8 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -551,7 +566,9 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Fix issue with incorrect gateway arp

<!-- Describe the purpose of the PR so that if you looked at it in 6 months time it would be clear from the overview why this was created -->
## What does this change resolve?
Due to wrong ebtables rule overcloud vms received incorrect mac address for the gateway ip. I've fixed ebtables rule and added arp gratuitous step to make sure we invalidate gw mac in arp cache table when enable masquerade.

#### Open questions or TODOs before merging if any
<!-- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!-- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->
https://wiki.wireshark.org/Gratuitous_ARP.md