### PR TITLE
[NOCARD] Add egressnetwork to use specific snat interface

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Package",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/main.go",
+            "asRoot": true,
+            "console": "integratedTerminal",
+            "env": {
+                "KUBECONFIG": "${userHome}/.kube/config",
+                "nodeName": "locahost",
+                "WATCH_NAMESPACE": "system"
+              }
+        }
+    ]
+}

--- a/api/v1alpha1/network_types.go
+++ b/api/v1alpha1/network_types.go
@@ -57,11 +57,11 @@ type Route struct {
 
 // Masquerade overcloud traffic
 type Masquerade struct {
-	Enabled bool     `json:"enabled"`
-	Source  string   `json:"source"`
-	Ignore  []string `json:"ignore,omitempty"`
-	Bridge  string   `json:"bridge,omitempty"`
-	Outface string   `json:"outface,omitempty"`
+	Enabled       bool     `json:"enabled"`
+	Source        string   `json:"source"`
+	Ignore        []string `json:"ignore,omitempty"`
+	Bridge        string   `json:"bridge,omitempty"`
+	EgressNetwork string   `json:"egressnetwork,omitempty"`
 }
 
 // NetworkStatus defines the observed state of Network

--- a/config/crd/bases/cloud.spaceship.com_networkattachments.yaml
+++ b/config/crd/bases/cloud.spaceship.com_networkattachments.yaml
@@ -65,14 +65,14 @@ spec:
                 properties:
                   bridge:
                     type: string
+                  egressnetwork:
+                    type: string
                   enabled:
                     type: boolean
                   ignore:
                     items:
                       type: string
                     type: array
-                  outface:
-                    type: string
                   source:
                     type: string
                 required:

--- a/config/crd/bases/cloud.spaceship.com_networks.yaml
+++ b/config/crd/bases/cloud.spaceship.com_networks.yaml
@@ -65,14 +65,14 @@ spec:
                 properties:
                   bridge:
                     type: string
+                  egressnetwork:
+                    type: string
                   enabled:
                     type: boolean
                   ignore:
                     items:
                       type: string
                     type: array
-                  outface:
-                    type: string
                   source:
                     type: string
                 required:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -57,3 +57,11 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch

--- a/controllers/firewall.go
+++ b/controllers/firewall.go
@@ -42,7 +42,7 @@ func EnableMasquerade(ipmasq *networkv1alpha1.Masquerade) error {
 		return err
 	}
 
-	if err := iptables.AddRule(ipmasq.Bridge, ipmasq.Source, ipmasq.Ignore, ipmasq.Outface); err != nil {
+	if err := iptables.AddRule(ipmasq.Bridge, ipmasq.Source, ipmasq.Ignore, ipmasq.EgressNetwork); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!-- Describe the purpose of the PR so that if you looked at it in 6 months time it would be clear from the overview why this was created -->
## What does this change resolve?
    * If egressnetwork is provided then iptables musquerade will use
      specific snat interface. For example:
      `iptables -t nat -I POSTROUTING -o bond0.2727 -J MASQUERADE`

#### Open questions or TODOs before merging if any
<!-- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!-- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->
